### PR TITLE
fix: preserve keywords order

### DIFF
--- a/xml_orgrfc/__main__.py
+++ b/xml_orgrfc/__main__.py
@@ -429,7 +429,7 @@ def top_level(root):
                     convert_xml_front(child, lines, 0)
                 keylist = [f'"{x}"' for x in glb.keywords]
                 if keylist:
-                    lines.append(f'#+RFC_KEYWORDS: ({" ".join(keylist)})\n')
+                    lines.append(f'#+RFC_KEYWORDS: ({" ".join(reversed(keylist))})\n')
             elif elt.tag == "middle":
                 logging.debug("processing middle tag")
                 for child in elt:


### PR DESCRIPTION
This is a minor fix.
The keywords were not preserving their original order. This fix ensures that the original order is maintained instead of reversing the array.